### PR TITLE
feat: wire TwinBattleCard into Today Dashboard (S94 UI wiring)

### DIFF
--- a/src/__tests__/twinBattle.test.js
+++ b/src/__tests__/twinBattle.test.js
@@ -54,4 +54,29 @@ describe("buildTwinBattle", () => {
     const result = buildTwinBattle({ resultFeedback: feedback }, { now: NOW });
     expect(result.review).toBeNull();
   });
+
+  it("leaderboard contains all three competitors sorted descending by P&L", () => {
+    const feedback = [
+      entry({ id: "1", profit: 10 }),
+      entry({ id: "2", profit: -5 }),
+    ];
+    const result = buildTwinBattle({ resultFeedback: feedback }, { now: NOW });
+    expect(result.empty).toBe(false);
+    expect(result.leaderboard).toHaveLength(3);
+    expect(result.leaderboard.map((r) => r.name)).toEqual(
+      expect.arrayContaining(["you", "twin", "disciplineTwin"]),
+    );
+    for (let i = 0; i < result.leaderboard.length - 1; i++) {
+      expect(result.leaderboard[i].pnl).toBeGreaterThanOrEqual(result.leaderboard[i + 1].pnl);
+    }
+  });
+
+  it("exposes delta fields required for gap indicators in the UI", () => {
+    const feedback = [entry({ id: "1", profit: 5 })];
+    const result = buildTwinBattle({ resultFeedback: feedback }, { now: NOW });
+    expect(result.empty).toBe(false);
+    expect(typeof result.delta.twinVsYou).toBe("number");
+    expect(typeof result.delta.disciplineVsYou).toBe("number");
+    expect(typeof result.windowDays).toBe("number");
+  });
 });

--- a/src/components/dashboard/TodayDashboardPanel.jsx
+++ b/src/components/dashboard/TodayDashboardPanel.jsx
@@ -17,6 +17,7 @@ import { buildDecisionJournal } from "../../lib/decisionJournal.js";
 import { computeDisciplineScore } from "../../lib/discipline.js";
 import { assertShareCardPiiSafe, buildShareCardData, renderShareCardCanvas } from "../../lib/shareCard.js";
 import { readTrustReceipts } from "../../lib/trustReceipts.js";
+import { buildTwinBattle } from "../../lib/twinBattle.js";
 
 function OperatorTwinCard({ forecast }) {
   if (!forecast) return null;
@@ -28,6 +29,58 @@ function OperatorTwinCard({ forecast }) {
       </div>
       <div style={{ fontSize: 12, color: K.tx, fontWeight: 700, marginBottom: 2 }}>{forecast.headline}</div>
       <div style={{ fontSize: 10, color: K.mt, lineHeight: 1.6 }}>{forecast.detail}</div>
+    </div>
+  );
+}
+
+function TwinBattleCard({ battle }) {
+  if (!battle) return null;
+  if (battle.empty) {
+    return (
+      <div style={{ padding: "10px 12px", background: K.s2, border: `1px solid ${K.bd}`, borderRadius: 8, marginBottom: 12 }}>
+        <div style={{ fontSize: 10, color: K.mt, textTransform: "uppercase", letterSpacing: "1.2px", fontWeight: 800, marginBottom: 4 }}>Twin Battle · 7-Day P&amp;L</div>
+        <div style={{ fontSize: 11, color: K.dm, lineHeight: 1.6 }}>Settle outcomes over the next 7 days to unlock your personal P&amp;L leaderboard vs. your best-self twin and discipline twin.</div>
+      </div>
+    );
+  }
+  const LABELS = { you: "You", twin: "Best-Self Twin", disciplineTwin: "Discipline Twin" };
+  const top = battle.leaderboard[0]?.name;
+  return (
+    <div style={{ padding: "12px", background: `${K.pp}08`, border: `1px solid ${K.pp}30`, borderRadius: 8, marginBottom: 12 }}>
+      <div style={{ fontSize: 10, color: K.pp, textTransform: "uppercase", letterSpacing: "1.2px", fontWeight: 800, marginBottom: 8 }}>
+        Twin Battle · 7-Day P&amp;L · {battle.sample} outcome{battle.sample !== 1 ? "s" : ""}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: battle.review ? 10 : 0 }}>
+        {battle.leaderboard.map((row, i) => {
+          const isYou = row.name === "you";
+          const tone = row.pnl >= 0 ? K.gn : K.rd;
+          const rank = ["1st", "2nd", "3rd"][i] || `${i + 1}th`;
+          return (
+            <div key={row.name} style={{
+              display: "flex", alignItems: "center", gap: 8,
+              padding: "7px 10px",
+              background: isYou ? `${K.pp}12` : K.s1,
+              border: `1px solid ${isYou ? K.pp : K.bd}40`,
+              borderRadius: 6,
+            }}>
+              <span style={{ fontSize: 9, color: K.mt, width: 24, flexShrink: 0 }}>{rank}</span>
+              <span style={{ fontSize: 11, color: isYou ? K.tx : K.dm, fontWeight: isYou ? 700 : 400, flex: 1 }}>
+                {LABELS[row.name] || row.name}
+                {row.name === top && !isYou ? <span style={{ marginLeft: 6, fontSize: 9, color: K.pp }}>LEADING</span> : null}
+              </span>
+              <span style={{ fontFamily: fontD, fontSize: 14, fontWeight: 800, color: tone }}>
+                {row.pnl >= 0 ? "+" : "-"}${Math.abs(row.pnl).toFixed(2)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {battle.review && (
+        <div style={{ fontSize: 10, color: K.mt, lineHeight: 1.6, borderTop: `1px solid ${K.bd}`, paddingTop: 8, marginTop: 4 }}>
+          <span style={{ color: K.yl, fontWeight: 700 }}>Biggest gap decision:</span>{" "}
+          {battle.review.book ? `${battle.review.book} · ` : ""}{battle.review.promo || "unknown promo"} · ${Math.abs(battle.review.profit).toFixed(2)} loss — review before next similar play.
+        </div>
+      )}
     </div>
   );
 }
@@ -200,6 +253,7 @@ export default function TodayDashboardPanel({ snapshot, navigate, appData = {}, 
   const { syncAppData, user } = React.useContext(AppDataCtx) || {};
   const counterfactual = React.useMemo(() => buildCounterfactualPnL(appData), [appData]);
   const journal = React.useMemo(() => buildDecisionJournal(appData), [appData]);
+  const twinBattle = React.useMemo(() => buildTwinBattle(appData), [appData]);
   const discipline = React.useMemo(() => computeDisciplineScore(appData), [appData]);
   const passportPlan = React.useMemo(() => getPromoPassportOnboardingPlan({
     appData,
@@ -290,6 +344,8 @@ export default function TodayDashboardPanel({ snapshot, navigate, appData = {}, 
       <TiltBreakerBanner state={computeTiltState(appData)} />
       <OperatorTwinCard forecast={buildTwinForecast(appData)} />
       <OperatorCommandRibbon counterfactual={counterfactual} journal={journal} onShare={shareBriefing} />
+
+      <TwinBattleCard battle={twinBattle} />
 
       <OperatorAutopilotCard decision={nextAction} topWorkflow={snapshot.topWorkflow} navigate={navigate} />
 


### PR DESCRIPTION
$(cat <<'EOF'
## What this advances

Wires the S93 `buildTwinBattle` lib into the Today Dashboard — the first UI surface from the S93 "Next move" list. The Today Dashboard is the landing view for every active operator, so this gives immediate visibility to the 3-way weekly P&L scorecard.

**What it does:**
- Adds `TwinBattleCard` component inside `TodayDashboardPanel`, positioned between the Operator Command Ribbon and the Autopilot card
- When settled outcomes exist in the last 7 days: shows a ranked 3-row leaderboard — **You / Best-Self Twin / Discipline Twin** — each with actual P&L, sorted descending
- When no settled outcomes: shows a sparse-history fallback prompt ("Settle outcomes over the next 7 days to unlock…")
- If losses exist, surfaces the **largest gap decision** below the leaderboard (book · promo type · loss amount) as a concrete review target — no medals, no shame copy
- Styling consistent with existing card palette; uses `K.pp` accent to distinguish this self-comparison card from the AI counterfactual ribbon (`K.ac`) above it

**Why this matters for SPARKED:**
- Directly rewards disciplined execution over raw volume (SOUL non-negotiable)
- Converts the S93 pure-lib investment into a user-facing signal on the highest-traffic screen
- Surfaces the "what would discipline have earned?" contrast that motivates closed-loop settlement behavior

**CANON-041 alignment:** compact leaderboard format with tone-graded P&L values and a concrete review prompt qualifies as elite, signal-dense operator intelligence surfacing.

## Files changed

| File | Change |
|------|--------|
| `src/components/dashboard/TodayDashboardPanel.jsx` | Add `TwinBattleCard` component + import + `useMemo` wire |
| `src/__tests__/twinBattle.test.js` | +2 tests: leaderboard sort invariant, delta field shape |

## Test plan

- [ ] `npm test` → 502/502 (was 500/500; +2 new tests)
- [ ] `npm run build` → clean, no warnings
- [ ] On Today Dashboard with settled outcomes in last 7 days: Twin Battle card appears between Operator Briefing and Autopilot card, showing 3 ranked rows with P&L
- [ ] On Today Dashboard with no settled history: card shows the sparse-history fallback copy
- [ ] When losses exist in the 7-day window: "Biggest gap decision" line appears below leaderboard with book/promo/amount
- [ ] When all outcomes are wins: no gap decision line rendered
- [ ] Mobile: card stacks cleanly within the existing dashboard layout (no horizontal overflow)

https://claude.ai/code/session_01SuuBnTRn2y613L3S15TAyg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuuBnTRn2y613L3S15TAyg)_