### PR TITLE
feat(profile): surface S93 bankroll stress test — Monte Carlo P10/P50/P90

### DIFF
--- a/src/components/ProfilePanel.jsx
+++ b/src/components/ProfilePanel.jsx
@@ -9,6 +9,7 @@ import { buildLocalDataExport, clearLocalPromoGrindData, describeDataControlStat
 import { buildReplayInsights } from "../lib/replayLedger.js";
 import { exportPassport } from "../lib/operatorPassport.js";
 import { compareKellyFractions } from "../lib/kellySim.js";
+import { runBankrollStress } from "../lib/bankrollStress.js";
 
 function PassportExportSection() {
   const ctx = useContext(AppDataCtx);
@@ -380,6 +381,94 @@ function KellySandboxSection() {
   );
 }
 
+// Converts American odds to implied win probability (vig-inclusive).
+function americanToWinProb(odds) {
+  const o = Number.parseFloat(odds);
+  if (!Number.isFinite(o)) return 0.5;
+  return o >= 0 ? 100 / (o + 100) : Math.abs(o) / (Math.abs(o) + 100);
+}
+
+// Converts American odds + stake to expected payout on a win.
+function americanToPayoutOnWin(stake, odds) {
+  const s = Number.parseFloat(stake);
+  const o = Number.parseFloat(odds);
+  if (!Number.isFinite(s) || s <= 0) return 0;
+  if (!Number.isFinite(o)) return s;
+  return o >= 0 ? s * (o / 100) : s * (100 / Math.abs(o));
+}
+
+function BankrollStressSection() {
+  const ctx = useContext(AppDataCtx);
+
+  const { stress, exposurePct } = useMemo(() => {
+    const bets = Array.isArray(ctx?.appData?.bets) ? ctx.appData.bets : [];
+    const bankroll = Number.parseFloat(ctx?.appData?.bankroll);
+    if (!(bankroll > 0)) return { stress: null, exposurePct: 0 };
+
+    const openBets = bets.filter((b) => {
+      const s = String(b.status || '').toLowerCase();
+      return !['won', 'lost', 'settled', 'cancelled'].includes(s);
+    });
+    if (!openBets.length) return { stress: null, exposurePct: 0 };
+
+    const positions = openBets
+      .map((b) => {
+        const stake = Number.parseFloat(b.stake);
+        if (!(stake > 0)) return null;
+        const odds = b.odds ?? b.line ?? 0;
+        return {
+          stake,
+          winProb: americanToWinProb(odds),
+          payoutOnWin: americanToPayoutOnWin(stake, odds),
+        };
+      })
+      .filter(Boolean);
+
+    if (!positions.length) return { stress: null, exposurePct: 0 };
+
+    const totalStake = positions.reduce((s, p) => s + p.stake, 0);
+    const stress = runBankrollStress({ bankroll, positions, floor: 0 }, { iterations: 500, seed: 42 });
+    return { stress, exposurePct: Math.round((totalStake / bankroll) * 100) };
+  }, [ctx?.appData]);
+
+  if (!stress || stress.empty) return null;
+
+  const bankroll = Number.parseFloat(ctx?.appData?.bankroll) || 1;
+  const { p10, p50, p90 } = stress.results;
+  const isHighExposure = exposurePct >= 25;
+  const pColor = (v) => v >= bankroll ? K.gn : v >= bankroll * 0.85 ? K.yl : K.rd;
+
+  return (
+    <div style={{ padding: '14px 20px', borderBottom: `1px solid ${K.bd}` }}>
+      <div style={{ fontSize: 10, fontWeight: 700, color: K.dm, textTransform: 'uppercase', letterSpacing: '1.5px', marginBottom: 6, display: 'flex', alignItems: 'center', gap: 8 }}>
+        Bankroll Stress Test
+        {isHighExposure && (
+          <span style={{ padding: '1px 6px', background: `${K.yl}20`, border: `1px solid ${K.yl}50`, borderRadius: 4, color: K.yl, fontSize: 9, fontWeight: 700, letterSpacing: '0.5px' }}>
+            {exposurePct}% exposed
+          </span>
+        )}
+      </div>
+      <div style={{ fontSize: 10, color: K.mt, lineHeight: 1.5, marginBottom: 10 }}>
+        {stress.iterations} Monte Carlo runs across {stress.positions} open bet{stress.positions !== 1 ? 's' : ''} — P10 is the pessimistic case.
+      </div>
+      <div style={{ display: 'flex', gap: 6, marginBottom: stress.floorBreachRate > 0 ? 8 : 0 }}>
+        {[['P10', p10, 'pessimistic'], ['P50', p50, 'median'], ['P90', p90, 'optimistic']].map(([label, val, hint]) => (
+          <div key={label} style={{ flex: 1, padding: '8px 10px', background: K.s2, border: `1px solid ${K.bd}`, borderRadius: 6, textAlign: 'center' }}>
+            <div style={{ fontSize: 9, color: K.mt, textTransform: 'uppercase', letterSpacing: '1px', marginBottom: 3 }}>{label}</div>
+            <div style={{ fontSize: 13, fontWeight: 700, color: pColor(val), fontFamily: font }}>${val.toFixed(0)}</div>
+            <div style={{ fontSize: 8, color: K.mt, marginTop: 2 }}>{hint}</div>
+          </div>
+        ))}
+      </div>
+      {stress.floorBreachRate > 0 && (
+        <div style={{ fontSize: 10, color: K.rd, padding: '6px 10px', background: `${K.rd}10`, border: `1px solid ${K.rd}25`, borderRadius: 6 }}>
+          Ruin risk: {Math.round(stress.floorBreachRate * 100)}% of simulations ended below floor — consider closing exposure before adding more.
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function ProfilePanel({
   user, proStatus, darkMode, toggleTheme,
   compactMode, toggleCompact, currency, setCurrency, onClose,
@@ -584,6 +673,9 @@ export default function ProfilePanel({
 
         {/* ── Kelly sandbox ────────────────────────────────────────── */}
         <KellySandboxSection />
+
+        {/* ── Bankroll stress test ─────────────────────────────────── */}
+        <BankrollStressSection />
 
         {/* ── Achievements ─────────────────────────────────────────── */}
         <AchievementsSection />


### PR DESCRIPTION
## What this advances

`src/lib/bankrollStress.js` was shipped in S93 with 6 tests, but was never wired to any UI — completely invisible to users. This PR makes it visible in the Profile panel, right after the Kelly Sandbox section where bankroll-intelligence context is already established.

### New: `BankrollStressSection` in ProfilePanel

- Pulls **open bets** from AppDataCtx and converts American odds → win probability + payout-on-win for each position
- Runs **500-iteration deterministic Monte Carlo** (Mulberry32, seed=42) — same approach as the tested lib
- Displays **P10 / P50 / P90 bankroll endpoints** in a 3-column card row, colour-graded:
  - Green ≥ starting bankroll
  - Yellow ≥ 85% of starting bankroll
  - Red below 85%
- Shows an **exposure badge** (`{X}% exposed`) when open stake ≥ 25% of bankroll
- Shows a **ruin-risk line** when any simulations breach the floor (floor = $0)
- Returns `null` when no bankroll is configured or no open bets exist — never renders empty state
- Placement: between `KellySandboxSection` and `AchievementsSection`

## What this advances toward SPARKED

Operators with $500–$5,000 bankrolls and 3–10 open bets now have a forward risk picture alongside their Kelly sizing review. The "pessimistic/median/optimistic" frame is direct operator intelligence, not gambling encouragement — consistent with SOUL.md's "high-signal trading desk" tone requirement.

## Files changed

| File | Change |
|---|---|
| `src/components/ProfilePanel.jsx` | Add `BankrollStressSection` component + `runBankrollStress` import + wire into profile JSX |

## Verify

1. Open the Profile panel with open bets in the tracker
2. Confirm "Bankroll Stress Test" section appears below Kelly Sandbox
3. P10/P50/P90 cards render with correct colour grading
4. With exposure ≥ 25% of bankroll: yellow "X% exposed" badge appears
5. No open bets → section is hidden (no empty state shown)
6. No bankroll set → section is hidden
7. `npm test` → 500/500 ✓
8. `npm run build` → clean ✓

---

> **Note for reviewer:** There are currently 4 open PRs (#4, #9, #10, #11) all targeting the same CANON-041 mobile nav improvement. They should be reviewed/consolidated before more mobile nav work is added. This PR covers a different gap entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyowP38UidcPf3JSbRyJkk)_