### PR TITLE
feat(mobile-nav): CANON-041 — 100dvh all-tools nav drawer for mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import { CANONICAL_APP_URL, FEATURE_FLAGS, getProjectAuthHref, getProjectAuthMod
 import { trackFeatureEnabledUse, trackFeatureGateClick, trackFeatureGateSeen, trackLaunchEvent } from "./launchTelemetry.js";
 import { trackEvent, trackPage, identifyUser } from "./analytics.js";
 import { MOBILE_NAV_RESPONSIVE_CSS } from "./app/responsive.js";
+import { MobileNavDrawer } from "./app/MobileNavDrawer.jsx";
 import { ToastCtx, useToast, AppDataCtx, FX, CurrencyCtx } from "./contexts.jsx";
 import { S, In, RR, Tl, Nt, FeatureUnavailableCard, useCalcMemory, shouldShowTrigger, dismissTrigger, Help, LoadingState } from "./ui.jsx";
 import { PROMO_SCHED, DAYS_ORDER } from "./data/promoSchedule.js";
@@ -1128,7 +1129,7 @@ const CalcSearch = ({ allCalcs, onNavigate, onClose }) => {
 };
 
 // â•â•â• MOBILE BOTTOM NAV â•â•â•
-const MobileBottomNav = ({ gi, goTo }) => {
+const MobileBottomNav = ({ gi, goTo, onOpenDrawer }) => {
   const icons = ["ðŸ ","âš¡","ðŸ“Š","ðŸ“ˆ","ðŸ”´","ðŸ“š"];
   const labels = ["Home","Convert","Calc","Track","Live","Learn"];
   return (
@@ -1140,6 +1141,10 @@ const MobileBottomNav = ({ gi, goTo }) => {
           <span style={{fontWeight:gi===i?700:400}}>{labels[i]}</span>
         </button>
       ))}
+      <button onClick={onOpenDrawer} aria-label="Browse all tools" style={{flex:0.8,padding:"7px 4px",background:"none",border:"none",borderLeft:`1px solid ${K.bd}`,color:K.mt,cursor:"pointer",fontSize:9,textTransform:"uppercase",letterSpacing:"0.5px",fontFamily:font,display:"flex",flexDirection:"column",alignItems:"center",gap:3}}>
+        <span style={{fontSize:18,lineHeight:1}}>☰</span>
+        <span>All</span>
+      </button>
     </div>
   );
 };
@@ -3047,6 +3052,7 @@ export default function App() {
   const [proStatus, setProStatus] = useState(null);
   const [authModalMode, setAuthModalMode] = useState(() => getInitialAuthMode());
   const [showPromoAdvisor, setShowPromoAdvisor] = useState(false);
+  const [showMobileNavDrawer, setShowMobileNavDrawer] = useState(false);
   const {
     darkMode,
     toggleTheme,
@@ -3758,7 +3764,10 @@ export default function App() {
       <EmailCapture/>
       <AppFooter/>
       {isMobile && <div style={{height:82}}/>}
-      <MobileBottomNav gi={gi} goTo={goTo}/>
+      <MobileBottomNav gi={gi} goTo={goTo} onOpenDrawer={() => setShowMobileNavDrawer(true)}/>
+      {showMobileNavDrawer && isMobile && (
+        <MobileNavDrawer tabs={TABS} gi={gi} ti={ti} navigate={navigate} onClose={() => setShowMobileNavDrawer(false)} />
+      )}
       <Suspense fallback={null}>
         {showPromoAdvisor && <PromoAdvisorPanel user={user} proStatus={proStatus} onClose={() => setShowPromoAdvisor(false)} />}
         <PromoChat navigate={navigate}/>

--- a/src/__tests__/mobileNavDrawer.test.jsx
+++ b/src/__tests__/mobileNavDrawer.test.jsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("../lib/shared.js", () => ({
+  K: {
+    bg: "#0f172a", gn: "#4ade80", mt: "#475569", tx: "#f1f5f9",
+    bd: "#1e293b", bd2: "#334155", pp: "#a855f7",
+  },
+  font: "sans-serif",
+  fontD: "monospace",
+}));
+
+import { MobileNavDrawer } from "../app/MobileNavDrawer.jsx";
+
+const TABS = [
+  { group: "Home", items: [
+    { n: "Dashboard", slug: "dashboard" },
+    { n: "Daily Brief", slug: "daily-brief" },
+  ]},
+  { group: "Convert", items: [
+    { n: "Bonus Bet", slug: "bonus-bet" },
+    { n: "Profit Boost", slug: "profit-boost" },
+  ]},
+  { group: "Live", items: [
+    { n: "Arb Scanner", slug: "arb-scanner", pro: true },
+  ]},
+];
+
+describe("MobileNavDrawer — CANON-041 100dvh mobile nav", () => {
+  it("renders an accessible dialog with all group sections and item buttons", () => {
+    render(
+      <MobileNavDrawer tabs={TABS} gi={0} ti={0} navigate={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("ALL TOOLS")).toBeTruthy();
+    expect(screen.getByTestId("nav-item-dashboard")).toBeTruthy();
+    expect(screen.getByTestId("nav-item-bonus-bet")).toBeTruthy();
+    expect(screen.getByTestId("nav-item-arb-scanner")).toBeTruthy();
+  });
+
+  it("calls navigate and onClose when an item is tapped", () => {
+    const navigate = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <MobileNavDrawer tabs={TABS} gi={0} ti={0} navigate={navigate} onClose={onClose} />
+    );
+    fireEvent.click(screen.getByTestId("nav-item-bonus-bet"));
+    expect(navigate).toHaveBeenCalledWith("/bonus-bet");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when ESC is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <MobileNavDrawer tabs={TABS} gi={0} ti={0} navigate={vi.fn()} onClose={onClose} />
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when the backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <MobileNavDrawer tabs={TABS} gi={0} ti={0} navigate={vi.fn()} onClose={onClose} />
+    );
+    fireEvent.click(screen.getByTestId("mobile-nav-backdrop"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("highlights the active group item and shows PRO badge on gated tools", () => {
+    render(
+      <MobileNavDrawer tabs={TABS} gi={1} ti={0} navigate={vi.fn()} onClose={vi.fn()} />
+    );
+    const activeBtn = screen.getByTestId("nav-item-bonus-bet");
+    expect(activeBtn.style.color).toBe("#4ade80");
+    expect(activeBtn.style.fontWeight).toBe("600");
+    expect(screen.getByText("PRO")).toBeTruthy();
+  });
+});

--- a/src/app/MobileNavDrawer.jsx
+++ b/src/app/MobileNavDrawer.jsx
@@ -1,0 +1,157 @@
+// 100dvh slide-up navigation overlay for mobile (CANON-041)
+// Gives mobile users full desktop-parity tool access in a single scrollable panel.
+import React, { useEffect } from "react";
+import { K, font, fontD } from "../lib/shared.js";
+
+const GROUP_ICONS = {
+  Home:      "🏠",
+  Convert:   "⚡",
+  Calculate: "📊",
+  Track:     "📈",
+  Live:      "🔴",
+  Learn:     "📚",
+};
+
+export function MobileNavDrawer({ tabs, gi, ti, navigate, onClose }) {
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = prev; };
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const go = (slug) => { navigate("/" + slug); onClose(); };
+
+  return (
+    <>
+      <div
+        data-testid="mobile-nav-backdrop"
+        onClick={onClose}
+        style={{
+          position: "fixed", inset: 0, zIndex: 490,
+          background: "rgba(0,0,0,0.55)",
+          backdropFilter: "blur(3px)",
+          WebkitBackdropFilter: "blur(3px)",
+        }}
+      />
+      <div
+        data-testid="mobile-nav-drawer"
+        role="dialog"
+        aria-label="All tools navigation"
+        aria-modal="true"
+        style={{
+          position: "fixed", inset: 0, zIndex: 500,
+          background: K.bg,
+          overflowY: "auto",
+          overscrollBehavior: "contain",
+          WebkitOverflowScrolling: "touch",
+          height: "100dvh",
+          animation: "pgNavIn 0.26s cubic-bezier(0.32,0.72,0,1) both",
+        }}
+      >
+        <style>{`
+          @keyframes pgNavIn {
+            from { transform: translateY(55%); opacity: 0.7; }
+            to   { transform: translateY(0);   opacity: 1; }
+          }
+        `}</style>
+
+        {/* Drag handle */}
+        <div style={{ display: "flex", justifyContent: "center", padding: "14px 0 6px" }}>
+          <div style={{ width: 44, height: 4, borderRadius: 2, background: K.bd2 }} />
+        </div>
+
+        {/* Header */}
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "6px 20px 14px",
+          borderBottom: `1px solid ${K.bd}`,
+        }}>
+          <div style={{
+            fontFamily: fontD, fontSize: 15, fontWeight: 800,
+            color: K.gn, letterSpacing: "0.5px",
+          }}>
+            ALL TOOLS
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close navigation"
+            style={{
+              padding: "5px 14px", background: "transparent",
+              border: `1px solid ${K.bd2}`, borderRadius: 6,
+              color: K.mt, fontSize: 11, cursor: "pointer", fontFamily: font,
+            }}
+          >
+            Done
+          </button>
+        </div>
+
+        {/* Groups + items */}
+        <div style={{ padding: "8px 0 120px" }}>
+          {tabs.map((tab, gIdx) => {
+            const icon = GROUP_ICONS[tab.group] || "▸";
+            const isActiveGroup = gIdx === gi;
+            return (
+              <div key={tab.group} style={{ marginBottom: 4 }}>
+                <div style={{
+                  display: "flex", alignItems: "center", gap: 7,
+                  padding: "10px 20px 5px",
+                }}>
+                  <span style={{ fontSize: 15 }}>{icon}</span>
+                  <span style={{
+                    fontFamily: font, fontSize: 9, fontWeight: 700,
+                    color: isActiveGroup ? K.gn : K.mt,
+                    textTransform: "uppercase", letterSpacing: "1.8px",
+                  }}>
+                    {tab.group}
+                  </span>
+                </div>
+                <div style={{
+                  display: "grid", gridTemplateColumns: "1fr 1fr",
+                  gap: 3, padding: "0 12px",
+                }}>
+                  {tab.items.map((item, iIdx) => {
+                    const isActive = isActiveGroup && iIdx === ti;
+                    return (
+                      <button
+                        key={item.slug}
+                        data-testid={`nav-item-${item.slug}`}
+                        onClick={() => go(item.slug)}
+                        style={{
+                          padding: "10px 11px",
+                          background: isActive ? `${K.gn}15` : "transparent",
+                          border: `1px solid ${isActive ? `${K.gn}60` : K.bd}`,
+                          borderRadius: 7,
+                          color: isActive ? K.gn : K.tx,
+                          fontSize: 12, fontWeight: isActive ? 600 : 400,
+                          cursor: "pointer", fontFamily: font,
+                          textAlign: "left",
+                          display: "flex", alignItems: "center", gap: 5,
+                        }}
+                      >
+                        <span style={{ flex: 1 }}>{item.n}</span>
+                        {item.pro && (
+                          <span style={{
+                            fontSize: 7, color: K.pp, fontWeight: 700,
+                            textTransform: "uppercase", letterSpacing: "0.5px",
+                          }}>
+                            PRO
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## What this advances

Implements the CANON-041 **scrollable 100dvh mobile nav** requirement. Mobile users previously had to find tools by scrolling horizontal subtab rows — now a single "☰ All" tap opens a full-height overlay showing every tool across all six groups in a scannable 2-column grid.

This closes the desktop<->mobile parity gap: desktop shows all groups + subtabs simultaneously; mobile now gets the same full picture in a single gesture.

## Changes

### `src/app/MobileNavDrawer.jsx` (new)
- Full-height `100dvh` panel with spring slide-up animation (`cubic-bezier(0.32,0.72,0,1)`)
- All 6 groups rendered as labeled sections with 2-column item grid
- Active group/item highlighted in accent green; PRO badge on gated tools
- Backdrop blur overlay; body scroll locked while open
- ESC key, backdrop click, and "Done" button all dismiss
- `overscrollBehavior: contain` prevents scroll bleed into page behind

### `src/App.jsx`
- Import `MobileNavDrawer`
- `showMobileNavDrawer` state added alongside other modal states
- `MobileBottomNav` gains `onOpenDrawer` prop and a compact `☰ All` button (right-edge, `flex:0.8`, separated by a border)
- Drawer renders conditionally: `showMobileNavDrawer && isMobile` (no tablet/desktop impact)

### `src/__tests__/mobileNavDrawer.test.jsx` (new, 5 tests)
1. Renders accessible dialog with all groups and item buttons
2. `navigate` + `onClose` both fire on item tap
3. ESC calls `onClose`
4. Backdrop click calls `onClose`
5. Active item gets accent color/weight; PRO badge visible

## To verify

1. Open `https://promogrind.bet` on a phone (or DevTools mobile viewport ≤ 640px)
2. Confirm `☰ All` button appears at the far right of the bottom nav bar
3. Tap it — a full-height panel should slide up from the bottom showing all 6 groups
4. Tap any tool (e.g. "Bonus Bet") — should navigate there and dismiss the drawer
5. Test ESC, backdrop tap, and "Done" button all dismiss correctly
6. Confirm no change on desktop (≥ 769px) — the drawer mount is gated on `isMobile`
7. Run `npx vitest run mobileNavDrawer` — 5/5 should pass

---
_Generated by [Claude Code](https://claude.ai/code/session_012owTFWJoBTPnmZK637Q2XZ)_