### PR TITLE
feat(mobile): CANON-041 dvh shell + scroll-snap nav + bottom-nav active glow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,7 @@ import { useProfitNotifications } from "./app/useProfitNotifications.js";
 import { CANONICAL_APP_URL, FEATURE_FLAGS, getProjectAuthHref, getProjectAuthMode } from "./launchState.js";
 import { trackFeatureEnabledUse, trackFeatureGateClick, trackFeatureGateSeen, trackLaunchEvent } from "./launchTelemetry.js";
 import { trackEvent, trackPage, identifyUser } from "./analytics.js";
-import { MOBILE_NAV_RESPONSIVE_CSS } from "./app/responsive.js";
+import { MOBILE_NAV_RESPONSIVE_CSS, APP_SHELL_CSS } from "./app/responsive.js";
 import { ToastCtx, useToast, AppDataCtx, FX, CurrencyCtx } from "./contexts.jsx";
 import { S, In, RR, Tl, Nt, FeatureUnavailableCard, useCalcMemory, shouldShowTrigger, dismissTrigger, Help, LoadingState } from "./ui.jsx";
 import { PROMO_SCHED, DAYS_ORDER } from "./data/promoSchedule.js";
@@ -1135,8 +1135,9 @@ const MobileBottomNav = ({ gi, goTo }) => {
     <div className="pg-mobile-nav" style={{position:"fixed",bottom:0,left:0,right:0,background:`linear-gradient(180deg,${K.s1},${K.s2})`,borderTop:`1px solid ${K.bd}`,display:"flex",zIndex:100,padding:"6px 0 env(safe-area-inset-bottom,0px)",boxShadow:"0 -10px 24px rgba(0,0,0,0.22)"}}>
       <style>{MOBILE_NAV_RESPONSIVE_CSS}</style>
       {TABS.map((t,i)=>(
-        <button key={t.group} onClick={()=>goTo(i,0)} style={{flex:1,padding:"7px 4px",background:"none",border:"none",color:gi===i?K.gn:K.mt,cursor:"pointer",fontSize:9,textTransform:"uppercase",letterSpacing:"0.5px",fontFamily:font,display:"flex",flexDirection:"column",alignItems:"center",gap:3}}>
-          <span style={{fontSize:18, lineHeight:1}}>{icons[i]}</span>
+        <button key={t.group} className="pg-mobile-nav-btn" onClick={()=>goTo(i,0)} style={{flex:1,padding:"7px 4px",background:"none",border:"none",color:gi===i?K.gn:K.mt,cursor:"pointer",fontSize:9,textTransform:"uppercase",letterSpacing:"0.5px",fontFamily:font,display:"flex",flexDirection:"column",alignItems:"center",gap:3,position:"relative"}}>
+          {gi===i && <span aria-hidden style={{position:"absolute",top:0,left:"22%",right:"22%",height:2,borderRadius:"0 0 2px 2px",background:K.gn,boxShadow:`0 1px 8px ${K.gn}80`}}/>}
+          <span style={{fontSize:gi===i?20:18,lineHeight:1}}>{icons[i]}</span>
           <span style={{fontWeight:gi===i?700:400}}>{labels[i]}</span>
         </button>
       ))}
@@ -3352,7 +3353,8 @@ export default function App() {
   if (pathname === "/feature-flags") {
     return (
       <FeatureFlagProviders appData={appData} syncAppData={syncAppData} user={user} syncDiagnostics={syncDiagnostics} syncStatus={syncStatus} isOnline={isOnline}>
-      <div style={{ fontFamily: font, fontSize: 13, color: K.tx, background: K.bg, minHeight: "100vh", padding: 16 }}>
+      <div className="pg-app-shell" style={{ fontFamily: font, fontSize: 13, color: K.tx, background: K.bg, padding: 16 }}>
+        <style>{APP_SHELL_CSS}</style>
         <Suspense fallback={<div style={{ padding: 32 }}>Loading…</div>}>
           <FeatureFlagAdmin proStatus={proStatus} />
         </Suspense>
@@ -3403,7 +3405,7 @@ export default function App() {
 
   if (!authReady) {
     return (
-      <div style={{fontFamily:font,fontSize:13,color:K.tx,background:K.bg,minHeight:"100vh",display:"flex",alignItems:"center",justifyContent:"center",padding:"20px"}}>
+      <div className="pg-app-shell" style={{fontFamily:font,fontSize:13,color:K.tx,background:K.bg,display:"flex",alignItems:"center",justifyContent:"center",padding:"20px"}}><style>{APP_SHELL_CSS}</style>
         <div style={{maxWidth:480,width:"100%",textAlign:"center"}}>
           <div style={{fontFamily:fontD,fontSize:32,fontWeight:800,color:K.gn,marginBottom:4,letterSpacing:"-1px"}}>PROMOGRIND</div>
           <div style={{fontSize:12,color:K.mt,letterSpacing:"2px",textTransform:"uppercase",marginBottom:12}}>Free Sportsbook Promo Conversion Tools</div>
@@ -3442,7 +3444,8 @@ export default function App() {
   if (embedMode) {
     return (
       <AppProviders appData={appData} syncAppData={syncAppData} user={user} syncDiagnostics={syncDiagnostics} syncStatus={syncStatus} isOnline={isOnline} compactMode={compactMode} currencyCtxVal={currencyCtxVal}>
-      <div style={{fontFamily:font,fontSize:13,color:K.tx,background:K.bg,minHeight:"100vh",padding:16}}>
+      <div className="pg-app-shell" style={{fontFamily:font,fontSize:13,color:K.tx,background:K.bg,padding:16}}>
+        <style>{APP_SHELL_CSS}</style>
         <AppCalculatorRouter slug={slug} item={item} isLiveTool={isLiveTool} proStatus={proStatus} compareMode={false} calcGroupIndex={CALC_GI} groupIndex={gi} group={g} isDesktop={isDesktop} compareSlug={compareSlug} setCompareSlug={setCompareSlug} DailyDashboard={DailyDashboard} navigate={navigate} />
         {isEmbed && (
           <div style={{position:'fixed',bottom:8,right:12,fontSize:11,color:'#475569',opacity:0.7,zIndex:9999}}>
@@ -3456,7 +3459,8 @@ export default function App() {
 
   return (
     <AppProviders appData={appData} syncAppData={syncAppData} user={user} syncDiagnostics={syncDiagnostics} syncStatus={syncStatus} isOnline={isOnline} compactMode={compactMode} currencyCtxVal={currencyCtxVal}>
-    <div style={{fontFamily:font,fontSize:13,color:K.tx,background:K.bg,minHeight:"100vh"}}>
+    <div className="pg-app-shell" style={{fontFamily:font,fontSize:13,color:K.tx,background:K.bg}}>
+      <style>{APP_SHELL_CSS}</style>
       <CheckoutListener/>
       <AuthDialog
         open={!!authModalMode}
@@ -3651,7 +3655,7 @@ export default function App() {
         <style>{`
           .pg-tabs::-webkit-scrollbar { display: none; }
           .pg-tab-btn { -webkit-tap-highlight-color: transparent; }
-          .pg-tab-btn:active { opacity: 0.7; }
+          .pg-tab-btn:active { opacity: 0.75; }
         `}</style>
         <div className="pg-tabs pg-scroll-x" role="tablist" aria-label="Primary navigation" style={{display:'flex',maxWidth:shellMaxWidth,width:'100%'}}>
           {TABS.map((t,i)=>(

--- a/src/app/responsive.js
+++ b/src/app/responsive.js
@@ -11,6 +11,15 @@ export const BREAKPOINTS = {
 export const MOBILE_NAV_RESPONSIVE_CSS = [
   "@media (min-width: 769px) { .pg-mobile-nav { display: none !important; } }",
   "@media (max-width: 768px) { .pg-main-content { padding-bottom: 88px !important; } }",
+  "@media (max-width: 768px) { .pg-tabs { scroll-snap-type: x mandatory; } .pg-tab-btn { scroll-snap-align: start; } }",
+].join(" ");
+
+export const APP_SHELL_CSS = [
+  ".pg-app-shell { min-height: 100vh; min-height: 100dvh; }",
+  ".pg-tab-btn { transition: color 0.15s, background 0.15s, border-color 0.15s; }",
+  ".pg-tab-btn:focus-visible { outline: 2px solid currentColor; outline-offset: -2px; border-radius: 4px; }",
+  ".pg-mobile-nav-btn { transition: color 0.15s, transform 0.12s; }",
+  ".pg-mobile-nav-btn:active { transform: scale(0.88); }",
 ].join(" ");
 
 export function getViewportState(width = 1280) {


### PR DESCRIPTION
## What this advances

CANON-041 compliance: desktop↔mobile parity with no broken mobile nav and elite immersive visuals.

Three concrete gaps closed:

### 1. `100dvh` app shell (functional fix)
All four full-page container entry points (`main render`, `embed mode`, `auth loading`, `feature-flags admin`) used `min-height: 100vh`. On iOS Safari and mobile Chrome the address bar dynamically resizes the viewport — `vh` is frozen to the initial value, `dvh` tracks the live viewport. Content was being undersized or clipped when the address bar appeared/disappeared. The fix introduces a `pg-app-shell` CSS class that uses the correct cascade:
```css
.pg-app-shell { min-height: 100vh; min-height: 100dvh; }
```
Older browsers that don't understand `dvh` fall through to `100vh` gracefully.

### 2. Scroll-snap on the mobile tab bar (UX fix)
The primary tab bar on phone widths (`≤768px`) now uses `scroll-snap-type: x mandatory` / `scroll-snap-align: start`. Previously a swipe gesture could leave the bar stopped between tabs. Now it snaps cleanly to each tab boundary, matching native app feel.

### 3. Bottom-nav active indicator + transitions (elite visual)
- Each active bottom-nav button shows a 2 px green glow bar at its top edge (`background: K.gn; box-shadow: 0 1px 8px …80`) — consistent with the top tab bar's active underline pattern.
- Active icon renders at 20 px vs 18 px inactive, providing clear section legibility without cluttering small screens.
- `.pg-tab-btn` gets a `0.15s` transition on `color / background / border-color` so tab changes aren't abrupt.
- `.pg-mobile-nav-btn` gets a `0.12s scale` transition + `scale(0.88)` on `:active` for tactile feedback.

## Files changed
- `src/app/responsive.js` — added `APP_SHELL_CSS` export; extended `MOBILE_NAV_RESPONSIVE_CSS` with scroll-snap media query
- `src/App.jsx` — swapped all four `minHeight:"100vh"` containers to `pg-app-shell` class; imported `APP_SHELL_CSS`; improved `MobileBottomNav` active indicator; added `pg-mobile-nav-btn` class to nav buttons

## Verify

- [ ] On iOS Safari (or DevTools mobile emulation): scroll a page, then hide/show the address bar — content should fill the full viewport at all times without overflow or short-cut
- [ ] On a phone-width DevTools viewport: swipe the primary tab bar (Home / Convert / Calc / Track / Live / Learn) — tabs should snap to boundaries, not stop mid-button
- [ ] Active tab in the mobile bottom nav shows a green glow bar at the top of the button + slightly larger icon vs inactive tabs
- [ ] Tapping a bottom-nav button shows a brief scale-down press animation
- [ ] `npm test` — 500/500 ✅
- [ ] `npm run build` — clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GL6XSmPjLmqutsiswywtE5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GL6XSmPjLmqutsiswywtE5)_